### PR TITLE
Updates after the UAT-in-the-VO EN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@
 DOCNAME = VOResource
 
 # count up; you probably do not want to bother with versions <1.0
-DOCVERSION = 1.1
+DOCVERSION = 1.2
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2018-06-25
+DOCDATE = 2022-08-29
 
 # What is it you're writing: NOTE, WD, PR, or REC
-DOCTYPE = REC
+DOCTYPE = WD
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex

--- a/VOResource-v1.1.xsd
+++ b/VOResource-v1.1.xsd
@@ -691,8 +691,10 @@ For details, see http://ivoa.net/documents/Notes/XMLVers -->
                about the resource.  
              </xs:documentation>
              <xs:documentation>
-               Terms for Subject should be drawn from the Unified
-               Astronomy Thesaurus (http://astrothesaurus.org).
+             	The content of subject SHOULD be the fragment identifier of 
+             	the URI of a concept in the IVOA UAT 
+             	(http://www.ivoa.net/rdf/uat/), that is, a string like 
+             	“virtual-observatories”.
              </xs:documentation>
           </xs:annotation>
        </xs:element>

--- a/VOResource.tex
+++ b/VOResource.tex
@@ -429,7 +429,7 @@ font.
 \subsubsection{Language and Transliteration}
 
 Several VOResource elements contain natural language (e.g.,
-\xmlel{description}, \xmlel{title}, \xmlel{subject}).  In order to
+\xmlel{description} or \xmlel{title}).  In order to
 ensure reliable discovery, in core VOResource, these elements must
 contain English text, with US spelling strongly preferred; technically,
 an \xmlel{xml:lang} value of \texttt{en-US} is implied.
@@ -470,8 +470,8 @@ a trailing Z.
 % GENERATED: !schemadoc VOResource-v1.1.xsd UTCTimestamp
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:UTCTimestamp} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:UTCTimestamp} Type Schema Documentation}
 
 \noindent{\small
            A timestamp that is compliant with ISO8601 and fixes
@@ -503,8 +503,8 @@ employ the \xmlel{vr:UTCDateTime} type.
 % GENERATED: !schemadoc VOResource-v1.1.xsd UTCDateTime
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:UTCDateTime} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:UTCDateTime} Type Schema Documentation}
 
 \noindent{\small
            A date stamp that can be given to a precision of either a
@@ -936,8 +936,8 @@ by the VOResource schema definition.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Resource
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Resource} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Resource} Type Schema Documentation}
 
 \noindent{\small
            Any entity or component of a VO application that is
@@ -1196,8 +1196,8 @@ metadata.  The \xmlel{vr:ShortName} definition enforces the
 % GENERATED: !schemadoc VOResource-v1.1.xsd ShortName
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ShortName} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ShortName} Type Schema Documentation}
 
 \noindent{\small
          A short name or abbreviation given to something.
@@ -1230,8 +1230,8 @@ metadata.  The \xmlel{vr:ShortName} definition enforces the
 % GENERATED: !schemadoc VOResource-v1.1.xsd IdentifierURI
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:IdentifierURI} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:IdentifierURI} Type Schema Documentation}
 
 \noindent{\small
             A reference to a registry record.
@@ -1279,8 +1279,8 @@ The curation metadata described in the RM (section
 % GENERATED: !schemadoc VOResource-v1.1.xsd Curation
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Curation} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Curation} Type Schema Documentation}
 
 \noindent{\small
          Information regarding the general curation of a resource
@@ -1398,8 +1398,8 @@ thus, the identifier (which is encoded as an attribute) is optional.
 % GENERATED: !schemadoc VOResource-v1.1.xsd ResourceName
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ResourceName} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ResourceName} Type Schema Documentation}
 
 \noindent{\small
          The name of a potentially registered resource.  That is, the entity
@@ -1451,8 +1451,8 @@ type which bundles together the RM metadata \emph{Creator} and
 % GENERATED: !schemadoc VOResource-v1.1.xsd Creator
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Creator} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Creator} Type Schema Documentation}
 
 \noindent{\small
             The entity (e.g. person or organisation) primarily responsible 
@@ -1631,8 +1631,8 @@ VOResource 1.0 terms to the modern DataCite Metadata ones).
 % GENERATED: !schemadoc VOResource-v1.1.xsd Date
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{1ex}\noindent\textbf{\xmlel{vr:Date} Type Schema Definition}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{1ex}\noindent\textbf{\xmlel{vr:Date} Type Schema Definition}
 
 \begin{lstlisting}[language=XML,basicstyle=\footnotesize]
 <xs:complexType name="Date" >
@@ -1699,8 +1699,8 @@ and \emph{Contact.Email}.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Contact
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Contact} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Contact} Type Schema Documentation}
 
 \noindent{\small
           Information allowing establishing contact, e.g., for purposes
@@ -1820,8 +1820,8 @@ defined by the \xmlel{vr:Content} complex type.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Content
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Content} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Content} Type Schema Documentation}
 
 \noindent{\small
          Information regarding the general content of a resource
@@ -1858,8 +1858,10 @@ defined by the \xmlel{vr:Content} complex type.
              
 \item[Occurrence] required; multiple occurrences allowed.
 \item[Comment] 
-               Terms for Subject should be drawn from the Unified
-               Astronomy Thesaurus (http://astrothesaurus.org).
+             	The content of subject SHOULD be the fragment identifier of 
+             	the URI of a concept in the IVOA UAT 
+             	(http://www.ivoa.net/rdf/uat/), that is, a string like 
+             	“virtual-observatories”.
              
 
 \end{description}
@@ -1949,6 +1951,12 @@ defined by the \xmlel{vr:Content} complex type.
 
 % /GENERATED
 
+The content of \xmlel{subject} should be drawn from the Unified
+Astronomy Thesaurus, the concepts of which are identified through
+human-readable fragments given in the IVOA-flavoured UAT at
+http://www.ivoa.net/rdf/uat.  The details and the rationale of the
+IVOA's use of the UAT are discussed in \citet{2022ivoa.spec.0722D}.
+
 The content of \xmlel{contentLevel} should conform to the values from a
 vocabulary.  At the time of writing, this vocabulary contained the
 terms:
@@ -2013,8 +2021,8 @@ The \xmlel{source} element's type,
 % GENERATED: !schemadoc VOResource-v1.1.xsd Source
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{1ex}\noindent\textbf{\xmlel{vr:Source} Type Schema Definition}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{1ex}\noindent\textbf{\xmlel{vr:Source} Type Schema Definition}
 
 \begin{lstlisting}[language=XML,basicstyle=\footnotesize]
 <xs:complexType name="Source" >
@@ -2108,8 +2116,8 @@ please refer to \url{http://www.ivoa.net/rdf/voresource/relationship_type}.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Relationship
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Relationship} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Relationship} Type Schema Documentation}
 
 \noindent{\small
            A description of the relationship between one resource and one or
@@ -2198,8 +2206,8 @@ assigned by different organisations.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Validation
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Validation} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Validation} Type Schema Documentation}
 
 \noindent{\small
          a validation stamp combining a validation level and the ID of 
@@ -2242,8 +2250,8 @@ assigned by different organisations.
 % GENERATED: !schemadoc VOResource-v1.1.xsd ValidationLevel
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ValidationLevel} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:ValidationLevel} Type Schema Documentation}
 
 \noindent{\small
          The allowed values for describing the resource descriptions
@@ -2345,8 +2353,8 @@ elements to the core set of metadata, \xmlel{facility} and
 % GENERATED: !schemadoc VOResource-v1.1.xsd Organisation
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Organisation} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Organisation} Type Schema Documentation}
 
 \noindent{\small
            A named group of one or more persons brought together to pursue 
@@ -2448,8 +2456,8 @@ invoked.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Service
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Service} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Service} Type Schema Documentation}
 
 \noindent{\small
            a resource that can be invoked by a client to perform some action
@@ -2542,8 +2550,8 @@ in the first \xmlel{rights} element.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Rights
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Rights} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Rights} Type Schema Documentation}
 
 \noindent{\small
             A statement of usage conditions.  This will typically
@@ -2614,8 +2622,8 @@ different capability of the service.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Capability
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Capability} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Capability} Type Schema Documentation}
 
 \noindent{\small
             a description of what the service does (in terms of 
@@ -2760,8 +2768,8 @@ discussed sect.~\ref{sect:servicemodel}.
 % GENERATED: !schemadoc VOResource-v1.1.xsd Interface
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Interface} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:Interface} Type Schema Documentation}
 
 \noindent{\small
             A description of a service interface.
@@ -2952,8 +2960,8 @@ record.  To aid in user interfaces for mirror selection,
 % GENERATED: !schemadoc VOResource-v1.1.xsd MirrorURL
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:MirrorURL} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:MirrorURL} Type Schema Documentation}
 
 \noindent{\small
             A URL of a mirror (i.e., a functionally identical additional 
@@ -3004,8 +3012,8 @@ defined as a complex type but with empty content:
 % GENERATED: !schemadoc VOResource-v1.1.xsd SecurityMethod
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:SecurityMethod} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:SecurityMethod} Type Schema Documentation}
 
 \noindent{\small
             a description of a security mechanism.
@@ -3076,8 +3084,8 @@ service.
 % GENERATED: !schemadoc VOResource-v1.1.xsd WebBrowser
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:WebBrowser} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:WebBrowser} Type Schema Documentation}
 
 \noindent{\small
             A (form-based) interface intended to be accesed interactively 
@@ -3117,8 +3125,8 @@ sub-type available from the VOResource schema:
 % GENERATED: !schemadoc VOResource-v1.1.xsd WebService
 \begin{generated}
 \begingroup
-      	\renewcommand*\descriptionlabel[1]{%
-      	\hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:WebService} Type Schema Documentation}
+        \renewcommand*\descriptionlabel[1]{%
+        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vr:WebService} Type Schema Documentation}
 
 \noindent{\small
             A Web Service that is describable by a WSDL document.
@@ -3186,6 +3194,11 @@ interface.  See sect.~\ref{sect:servicemodel} for details.
 \appendix
 
 \section{Change History}
+
+\subsection{Changes from REC-1.1}
+
+We now specify that ``using the UAT'' from version 1.1 means ``use
+fragments into \nolinkurl{http://www.ivoa.net/rdf/uat#}.
 
 \subsection{Changes from PR-20171107}
 

--- a/example-voresource.xml
+++ b/example-voresource.xml
@@ -36,10 +36,10 @@
     </curation> 
 
     <content> 
-        <subject>radio astronomy</subject> 
-        <subject>data repositories</subject> 
-        <subject>digital libraries </subject> 
-        <subject>grid-based processing</subject> 
+        <subject>radio-astronomy</subject> 
+        <subject>astronomy-software</subject> 
+        <subject>astronomy-web-services </subject> 
+        <subject>search-for-extraterrestrial-intelligence</subject> 
         <description> 
             The Radio Astronomy Imaging Group at the National Center for 
             Supercomputing Applications is focused on applying 


### PR DESCRIPTION
Rationale:

VOResource 1.1 says in the documentation of the subject element: "Terms
for Subject should be drawn from the Unified Astronomy Thesaurus
(http://astrothesaurus.org)."

This prescription is not suffient in practice; for many reasons, we
cannot really use the UAT concept URIs (for instance,
http://astrothesaurus.org/uat/11 for "The relative amount of a given
chemical element with respect to other elements") in VOResource.  The
label (in the example, "Abundance ratios") is not necessarily stable and
suffers from case and potentially punctuation issues.

To have a solid foundation for UAT use in VOResource, a specific scheme
has recently been endorsed in the VO, "Adopting the UAT as an IVOA
vocabulary", https://ivoa.net/documents/uat-as-upstream/.  This is what
should now be used in VOResource, and hence the document should contain
a pointer to the UAT adoption note.  This erratum introduces these
pointers and updates an example to the modern practice.

Impact Assessment:

At the moment subject simply is not machine-readable and hence its
content is treated as plain text.  TOPCAT, for instance, translates
subject constraints into 

```
LOWER(res_subject) like '%keyword%'.
```

These will obviously keep working as before (except if a data provider
actually had introduced upstream UAT URIs; none has, so far).

The syntax chosen in the UAT note – words separated by hyphens – also
makes queries using ivo_haswords work as before.  During the review
phase of this erratum, the TAP service at http://dc.g-vo.org/tap carries
table rr.uat_concept that reflects how rr.res_subject will look like
once the UAT migration is finished.  To illustrate the effects on
queries using haswords, try:

```
select distinct uat_concept from rr.subject_uat
where 1=ivo_hasword(uat_concept, 'radio')
```

there.

Hence, we do not expect noticable negative impact.  On the other hand, a
migration to the scheme forseen here will enable many useful
applications, starting from reliable keyword matching to semantics-based
query expansion to subject mapping for interdisciplinary metadata
repositories (cf.
https://blog.g-vo.org/semantics-cross-discipline-discovery-and-down-to-earth-code.html).