### PR TITLE
Forcing referenceURLs to be http(s) URIs.

### DIFF
--- a/VOResource-v1.2.xsd
+++ b/VOResource-v1.2.xsd
@@ -6,10 +6,10 @@
            xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
            elementFormDefault="unqualified"
            attributeFormDefault="unqualified"
-           version="1.1+Erratum-1">
+           version="1.1+wd1">
 
 <!-- NOTE: target namespace ends in v1.0 in order to not break 1.0 clients.
-This is nevertheless the 1.1 schema, as given by the version attribute.
+This is nevertheless the 1.2 schema, as given by the version attribute.
 For details, see http://ivoa.net/documents/Notes/XMLVers -->
 
    <xs:annotation>
@@ -738,13 +738,23 @@ For details, see http://ivoa.net/documents/Notes/XMLVers -->
           </xs:annotation>
        </xs:element>
        
-       <xs:element name="referenceURL" type="xs:anyURI">
+       <xs:element name="referenceURL">
           <xs:annotation>
              <xs:documentation>
                 URL pointing to a human-readable document describing this 
                 resource.   
              </xs:documentation>
+             <xs:documentation>
+             	In order to ensure that users can actually retrieve the
+             	content, the schema enforces this to be an http or https
+             	URI.
+             </xs:documentation>
           </xs:annotation>
+          <xs:simpleType>
+             <xs:restriction base="xs:anyURI">
+                <xs:pattern value="https?://.*"/>
+             </xs:restriction>
+          </xs:simpleType>
        </xs:element>
 
        <xs:element name="type" type="xs:token" 

--- a/VOResource.tex
+++ b/VOResource.tex
@@ -1836,7 +1836,13 @@ defined by the \xmlel{vr:Content} complex type.
               maxOccurs="unbounded" />
     <xs:element name="description" type="xs:string" />
     <xs:element name="source" type="vr:Source" minOccurs="0" />
-    <xs:element name="referenceURL" type="xs:anyURI" />
+    <xs:element name="referenceURL" >
+      <xs:simpleType >
+        <xs:restriction base="xs:anyURI" >
+          <xs:pattern value="https?://.*" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
     <xs:element name="type" type="xs:token" minOccurs="0"
               maxOccurs="unbounded" />
     <xs:element name="contentLevel" type="xs:token" minOccurs="0"
@@ -1902,12 +1908,18 @@ defined by the \xmlel{vr:Content} complex type.
 \end{description}
 \item[Element \xmlel{referenceURL}]
 \begin{description}
-\item[Type] a URI: \xmlel{xs:anyURI}
+\item[Type] string
 \item[Meaning] 
                 URL pointing to a human-readable document describing this 
                 resource.   
              
 \item[Occurrence] required
+
+\item[Comment] 
+             	In order to ensure that users can actually retrieve the
+             	content, the schema enforces this to be an http or https
+             	URI.
+             
 
 \end{description}
 \item[Element \xmlel{type}]


### PR DESCRIPTION
This was proposed in VOResource-1_1-Next; the rationale:

Various data providers get the reference URLs wrong (e.g., using plain domain names) or fail to give sensible values and are never reminded to put them in. The schema does not notice that because xs:anyURI is rather lenient (by necessity).

On the other hand, the having something a browser can in all likelihood deal with appears eminently useful. While that won't prevent 404s, just forcing referenceURL to start with https?:// would go a long way to ensure useful reference URLs.