### PR TITLE
Defining "doi" as a legal source format, too.

### DIFF
--- a/VOResource-v1.2.xsd
+++ b/VOResource-v1.2.xsd
@@ -6,7 +6,7 @@
            xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
            elementFormDefault="unqualified"
            attributeFormDefault="unqualified"
-           version="1.1+wd1">
+           version="1.1+wd2">
 
 <!-- NOTE: target namespace ends in v1.0 in order to not break 1.0 clients.
 This is nevertheless the 1.2 schema, as given by the version attribute.
@@ -808,7 +808,16 @@ For details, see http://ivoa.net/documents/Notes/XMLVers -->
                <xs:documentation>
                  The reference format.  Recognized values include “bibcode”, 
                  referring to a standard astronomical bibcode 
-                 (http://cdsweb.u-strasbg.fr/simbad/refcode.html).  
+                 (http://cdsweb.u-strasbg.fr/simbad/refcode.html), and
+                 “doi” for a Digital Object Identifier
+               </xs:documentation>
+               <xs:documentation>
+               	Since format already defines how to interpret source's
+               	values, these do not uses any prefixes, HTTP or otherwise.
+               	A resource would declare VOResource 1.1 as its source by
+               	writing 2018ivoa.spec.0625P with the bibcode format, and
+               	writing 10.5479/ADS/bib/2018ivoa.spec.0625P with the doi 
+               	format.
                </xs:documentation>
              </xs:annotation>
            </xs:attribute>

--- a/VOResource.tex
+++ b/VOResource.tex
@@ -27,7 +27,7 @@
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/TonyLinde]{Tony Linde}
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/GuyRixon]{Guy Rixon}
 
-\editor{Ray Plante, Markus Demleitner}
+\editor{Markus Demleitner}
 
 \previousversion[http://www.ivoa.net/Documents/REC/ReR/VOResource-20080222.html]{REC -1.03}
 \previousversion[http://www.ivoa.net/Documents/WD/ReR/VOResource-20061107.html]
@@ -271,7 +271,7 @@ The namespace URI has been chosen to allow it to be resolved as a URL
 to the XML Schema document that defines the VOResource schema.
 Applications may assume that the namespace URI is so resolvable.
 
-Although this schema is in version 1.1 now, the URL still ends in
+Although this schema is in version 1.2 now, the URL still ends in
 \texttt{v1.0}.  This is to avoid unnecessarily breaking existing clients
 relying on the namespace as defined by version 1.0 of this
 specification.  As laid out in the IVOA schema versioning policies
@@ -282,8 +282,8 @@ they cannot be dropped despite their potential for confusion.
 Clients should in general not care about minor versions of schemas.
 To cover
 the rare cases in which  such information is necessary, instance documents
-for version 1.1 of VOResource must have a \xmlel{version} attribute
-with value \texttt{1.1} on their root element (i.e., \xmlel{Resource}).
+for version 1.2 of VOResource must have a \xmlel{version} attribute
+with value \texttt{1.2} on their root element (i.e., \xmlel{Resource}).
 
 Document authors are strongly encouraged to bind this namespace to the
 \xmlel{vr:} prefix.  While in generic XML processing, the concrete
@@ -467,7 +467,7 @@ For historical reasons, VOResource also allows a form without any
 timezone marker.  Such timestamps are to be interpreted as  if they had
 a trailing Z.
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd UTCTimestamp
+% GENERATED: !schemadoc VOResource-v1.2.xsd UTCTimestamp
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -475,7 +475,7 @@ a trailing Z.
 
 \noindent{\small
            A timestamp that is compliant with ISO8601 and fixes
-           the timezone indicator, if present, to "Z" (UTC).  VOResource
+           the timezone indicator, if present, to {"}Z{"} (UTC).  VOResource
            writers should always include the timezone marker.  VOResource
            readers must interpret timestamps without a timezone marker as
            UTC.
@@ -500,7 +500,7 @@ Where day granularity might suffice for some instance documents,
 VOResource and extensions can
 employ the \xmlel{vr:UTCDateTime} type.
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd UTCDateTime
+% GENERATED: !schemadoc VOResource-v1.2.xsd UTCDateTime
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -933,7 +933,7 @@ by the VOResource schema definition.
 
 \goodbreak
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Resource
+% GENERATED: !schemadoc VOResource-v1.2.xsd Resource
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1193,7 +1193,7 @@ Two special types, \xmlel{vr:ShortName} and
 metadata.  The \xmlel{vr:ShortName} definition enforces the
 16-character limit on shortNames.  
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd ShortName
+% GENERATED: !schemadoc VOResource-v1.2.xsd ShortName
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1227,7 +1227,7 @@ metadata.  The \xmlel{vr:ShortName} definition enforces the
 
 % /GENERATED
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd IdentifierURI
+% GENERATED: !schemadoc VOResource-v1.2.xsd IdentifierURI
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1276,7 +1276,7 @@ The curation metadata described in the RM (section
 
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Curation
+% GENERATED: !schemadoc VOResource-v1.2.xsd Curation
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1395,7 +1395,7 @@ necessarily be registered and, therefore, will have an identifier;
 thus, the identifier (which is encoded as an attribute) is optional. 
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd ResourceName
+% GENERATED: !schemadoc VOResource-v1.2.xsd ResourceName
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1448,7 +1448,7 @@ type which bundles together the RM metadata \emph{Creator} and
 
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Creator
+% GENERATED: !schemadoc VOResource-v1.2.xsd Creator
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1628,7 +1628,7 @@ specification.  Applications are not expected to support semantic
 relationships between the terms (except for mapping the deprecated
 VOResource 1.0 terms to the modern DataCite Metadata ones).
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Date
+% GENERATED: !schemadoc VOResource-v1.2.xsd Date
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1696,7 +1696,7 @@ and \emph{Contact.Email}.
 
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Contact
+% GENERATED: !schemadoc VOResource-v1.2.xsd Contact
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1817,7 +1817,7 @@ child element \xmlel{content}.  Its content is
 defined by the \xmlel{vr:Content} complex type.
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Content
+% GENERATED: !schemadoc VOResource-v1.2.xsd Content
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -1917,7 +1917,7 @@ defined by the \xmlel{vr:Content} complex type.
 
 \item[Comment] 
              	In order to ensure that users can actually retrieve the
-             	content, the schema enforces this to be an http or https
+             	content, the schema enforces that this is an http or https
              	URI.
              
 
@@ -2030,7 +2030,7 @@ The \xmlel{source} element's type,
 \xmlel{format}.  
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Source
+% GENERATED: !schemadoc VOResource-v1.2.xsd Source
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2055,9 +2055,18 @@ The \xmlel{source} element's type,
 \item[Meaning] 
                  The reference format.  Recognized values include “bibcode”, 
                  referring to a standard astronomical bibcode 
-                 (http://cdsweb.u-strasbg.fr/simbad/refcode.html).  
+                 (http://cdsweb.u-strasbg.fr/simbad/refcode.html), and
+                 “doi” for a Digital Object Identifier
                
 \item[Occurrence] optional
+\item[Comment] 
+               	Since format already defines how to interpret source's
+               	values, these do not uses any prefixes, HTTP or otherwise.
+               	A resource would declare VOResource 1.1 as its source by
+               	writing 2018ivoa.spec.0625P with the bibcode format, and
+               	writing 10.5479/ADS/bib/2018ivoa.spec.0625P with the doi 
+               	format.
+               
 \end{description}
 
 
@@ -2125,7 +2134,7 @@ For definitions of these terms, their relationships, and the complete,
 up-to date list of the legal terms in HTML, turtle, or RDF-X formats,
 please refer to \url{http://www.ivoa.net/rdf/voresource/relationship_type}.
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Relationship
+% GENERATED: !schemadoc VOResource-v1.2.xsd Relationship
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2215,7 +2224,7 @@ multiple times, each with
 a different \xmlel{validatedBy} value, to reflect the code
 assigned by different organisations. 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Validation
+% GENERATED: !schemadoc VOResource-v1.2.xsd Validation
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2259,7 +2268,7 @@ assigned by different organisations.
 
 % /GENERATED
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd ValidationLevel
+% GENERATED: !schemadoc VOResource-v1.2.xsd ValidationLevel
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2362,7 +2371,7 @@ elements to the core set of metadata, \xmlel{facility} and
 \xmlel{instrument}:
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Organisation
+% GENERATED: !schemadoc VOResource-v1.2.xsd Organisation
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2465,7 +2474,7 @@ The Service type extends the Resource type by adding two elements:
 invoked.
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Service
+% GENERATED: !schemadoc VOResource-v1.2.xsd Service
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2559,7 +2568,7 @@ specifiation.  In practice, resource record authors should place all
 usage limitations, citation recommendations, etc., directed at VO users
 in the first \xmlel{rights} element.
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Rights
+% GENERATED: !schemadoc VOResource-v1.2.xsd Rights
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2631,7 +2640,7 @@ As described in sect.~\ref{sect:servicemodel}, multiple
 different capability of the service.  
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Capability
+% GENERATED: !schemadoc VOResource-v1.2.xsd Capability
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2777,7 +2786,7 @@ The \xmlel{interface} element is of the complex type
 use of its \xmlel{xsi:type} attribute and typical values thereof, is
 discussed sect.~\ref{sect:servicemodel}.
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd Interface
+% GENERATED: !schemadoc VOResource-v1.2.xsd Interface
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -2958,7 +2967,7 @@ documention conventions described in sect.~\ref{sect:core}.
 In version 1.0, operators of services with multiple mirrors were
 encouraged to give multiple \xmlel{accessURL} elements.  This feature
 was not used in practice, presumably for concerns users might end up on
-remote mirrors.  In version 1.1, we therefore deprecate multiple
+remote mirrors.  Since version 1.1, we therefore deprecate multiple
 \xmlel{accessURL} within an interface.  Access URLs of actual mirrors
 can now be declared using \xmlel{mirrorURL} elements.
 As before, neither 
@@ -2969,7 +2978,7 @@ record.  To aid in user interfaces for mirror selection,
 \xmlel{mirrorURL} admits a \xmlel{title} attribute:
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd MirrorURL
+% GENERATED: !schemadoc VOResource-v1.2.xsd MirrorURL
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -3021,7 +3030,7 @@ The \xmlel{vr:SecurityMethod} type is
 defined as a complex type but with empty content:
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd SecurityMethod
+% GENERATED: !schemadoc VOResource-v1.2.xsd SecurityMethod
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -3093,7 +3102,7 @@ the URL of a web page containing one or more forms used to invoke the
 service. 
 
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd WebBrowser
+% GENERATED: !schemadoc VOResource-v1.2.xsd WebBrowser
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%
@@ -3134,7 +3143,7 @@ may).  Thus, this type is provided purely for its semantic meaning.
 \xmlel{vr:WebService} is the second \xmlel{vr:Interface}
 sub-type available from the VOResource schema:
 
-% GENERATED: !schemadoc VOResource-v1.1.xsd WebService
+% GENERATED: !schemadoc VOResource-v1.2.xsd WebService
 \begin{generated}
 \begingroup
         \renewcommand*\descriptionlabel[1]{%


### PR DESCRIPTION
Also, removing Ray as an editor, as regrettably he is no longer acting as such.

DOIs in sources is as per the second item on https://wiki.ivoa.net/twiki/bin/view/IVOA/VOResource-1_1-Next