### PR TITLE
Fixing the bibcode definition.

### DIFF
--- a/VOResource.tex
+++ b/VOResource.tex
@@ -560,7 +560,8 @@ instructions\footnote{\url{https://support.orcid.org/knowledgebase/articles/1167
 as HTTPS URIs using orcid.org's infrastructure, for instance
 \url{https://orcid.org/0000-0001-2345-6789}.
 
-\item[bibcode] A bibliographic code as used by ADS and CDS.  These
+\item[bibcode] A bibliographic code as used by
+ADS and CDS \citep{1995ASSL..203..259S}.  These
 must be used with an ad-hoc URI scheme of \verb|bibcode|, as in
 \verb|bibcode:2008ivoa.spec.0222P|.
 
@@ -2132,8 +2133,7 @@ The \xmlel{source} element's type,
 \item[Type] string: \xmlel{xs:string}
 \item[Meaning]
                  The reference format.  Recognized values include “bibcode”,
-                 referring to a standard astronomical bibcode
-                 (\url{http://cdsweb.u-strasbg.fr/simbad/refcode.html}), and
+                 referring to a standard astronomical bibcode, and
                  “doi” for a Digital Object Identifier
 
 \item[Occurrence] optional

--- a/local.bib
+++ b/local.bib
@@ -8,3 +8,17 @@
    doi={14454/mzv1-5b55}
 }
 
+
+@INPROCEEDINGS{1995ASSL..203..259S,
+       author = {{Schmitz}, M. and {Helou}, G. and {Dubois}, P. and {Lague}, C. and {Madore}, B. and {Corwin}, Jr., H.~G. and {Lesteven}, S.},
+        title = "{NED and SIMBAD Conventions for Bibliographic Reference Coding}",
+     keywords = {Data Bases: Bibliography},
+    booktitle = {Information \& On-Line Data in Astronomy},
+         year = 1995,
+       editor = {{Egret}, D. and {Albrecht}, M.~A.},
+        month = jan,
+        pages = {259},
+          doi = {10.1007/978-94-011-0397-8_24},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1995ASSL..203..259S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}


### PR DESCRIPTION
The URL we've had in the schema documentation for what a bibcode is was broken.  This PR moves the reference from the schema (and the generated documentatoin) into the main narrative and now properly cites the paper introducing bibcodes.