### PR TITLE
Clarification of vs:Creator/name

### DIFF
--- a/VOResource-v1.3.xsd
+++ b/VOResource-v1.3.xsd
@@ -6,7 +6,7 @@
            xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
            elementFormDefault="unqualified"
            attributeFormDefault="unqualified"
-           version="1.3-wd1">
+           version="1.3-wd2">
 
 <!-- NOTE: target namespace ends in v1.0 in order to not break 1.0 clients.
 This is nevertheless the 1.3 schema, as given by the version attribute.
@@ -597,14 +597,17 @@ For details, see http://ivoa.net/documents/Notes/XMLVers -->
         <xs:element name="name" type="vr:ResourceName">
            <xs:annotation>
               <xs:documentation>
-                  the name or title of the creating person or organisation
+                  A name of a person or organisation that created
+                  the resource's (data) content.
               </xs:documentation>
               <xs:documentation>
-                  Users of the creation should use this name in
-                  subsequent credits and acknowledgements.
+                  In citations or acknowledgements, creator names are intended
+                  to be used in the author field.
 
-                  This should be exactly one name, preferably last name
-                  first (as in “van der Waals, Johannes Diderik”).
+                  Each creator should contain exactly one name, preferably last
+                  name first (as in “van der Waals, Johannes Diderik”).  Use
+                  multiple creator elements for resources created by multiple
+                  entities.
               </xs:documentation>
            </xs:annotation>
         </xs:element>

--- a/VOResource.tex
+++ b/VOResource.tex
@@ -1564,15 +1564,18 @@ type which bundles together the RM metadata \emph{Creator} and
 \begin{description}
 \item[Type] string with ID attribute: vr:ResourceName
 \item[Meaning]
-                  the name or title of the creating person or organisation
+                  A name of a person or organisation that created
+                  the resource's (data) content.
 
 \item[Occurrence] required
 \item[Comment]
-                  Users of the creation should use this name in
-                  subsequent credits and acknowledgements.
+                  In citations or acknowledgements, creator names are intended
+                  to be used in the author field.
 
-                  This should be exactly one name, preferably last name
-                  first (as in “van der Waals, Johannes Diderik”).
+                  Each creator should contain exactly one name, preferably last
+                  name first (as in “van der Waals, Johannes Diderik”).  Use
+                  multiple creator elements for resources created by multiple
+                  entities.
 
 
 \end{description}
@@ -2133,7 +2136,8 @@ The \xmlel{source} element's type,
 \item[Type] string: \xmlel{xs:string}
 \item[Meaning]
                  The reference format.  Recognized values include “bibcode”,
-                 referring to a standard astronomical bibcode, and
+                 referring to a standard astronomical bibcode
+                 (\url{http://cdsweb.u-strasbg.fr/simbad/refcode.html}), and
                  “doi” for a Digital Object Identifier
 
 \item[Occurrence] optional


### PR DESCRIPTION
In particular, the word "creation" in the element's documentation was rather confusing.  I also use the opportunity to pull the "title" from its description, as I don't think this term is helpful for either persons or organisation but might actually cause damage ("should I put in a PhD there?").

This is a stab at fixing bug #24.