### PR TITLE
Deprecating testQueryString of vr:Interface.

### DIFF
--- a/VOResource-v1.3.xsd
+++ b/VOResource-v1.3.xsd
@@ -6,7 +6,7 @@
            xmlns:vm="http://www.ivoa.net/xml/VOMetadata/v0.1"
            elementFormDefault="unqualified"
            attributeFormDefault="unqualified"
-           version="1.3-wd2">
+           version="1.3-wd3">
 
 <!-- NOTE: target namespace ends in v1.0 in order to not break 1.0 clients.
 This is nevertheless the 1.3 schema, as given by the version attribute.
@@ -1176,18 +1176,14 @@ For details, see http://ivoa.net/documents/Notes/XMLVers -->
                      minOccurs="0" maxOccurs="1">
             <xs:annotation>
                <xs:documentation>
-                  Test data for exercising the service.
+                  Deprecated: Test data for exercising the service.
                </xs:documentation>
                <xs:documentation>
-                  This contains data that can be passed to the interface to
-                  retrieve a non-empty result.  This can be used by validators
-                  within test suites.
-
-                  Exactly how agents should use the data contained in
-                  the testQueryString depends on the concrete interface class.
-                  For interfaces employing the HTTP GET method, however,
-                  this will typically be urlencoded parameters (as for
-                  the application/x-www-form-urlencoded media type).
+               	  This element was introduced in VOResource 1.1 in an
+               	  attempt to unify test query declarations over
+               	  SimpleDALRegExt and vs:ParamHTTP's testQuery.  This
+               	  turned out to be of no advantage.  Therefore, testQueryString
+               	  is deprecated in VOResource 1.4.
                </xs:documentation>
             </xs:annotation>
          </xs:element>

--- a/VOResource.tex
+++ b/VOResource.tex
@@ -3015,19 +3015,15 @@ discussed sect.~\ref{sect:servicemodel}.
 \begin{description}
 \item[Type] string: \xmlel{xs:token}
 \item[Meaning]
-                  Test data for exercising the service.
+                  Deprecated: Test data for exercising the service.
 
 \item[Occurrence] optional
 \item[Comment]
-                  This contains data that can be passed to the interface to
-                  retrieve a non-empty result.  This can be used by validators
-                  within test suites.
-
-                  Exactly how agents should use the data contained in
-                  the testQueryString depends on the concrete interface class.
-                  For interfaces employing the HTTP GET method, however,
-                  this will typically be urlencoded parameters (as for
-                  the application/x-www-form-urlencoded media type).
+               	  This element was introduced in VOResource 1.1 in an
+               	  attempt to unify test query declarations over
+               	  SimpleDALRegExt and vs:ParamHTTP's testQuery.  This
+               	  turned out to be of no advantage.  Therefore, testQueryString
+               	  is deprecated in VOResource 1.4.
 
 
 \end{description}
@@ -3306,6 +3302,7 @@ interface.  See sect.~\ref{sect:servicemodel} for details.
 \begin{itemize}
 \item Deprecated the \xmlel{ivo-id} attributes of \xmlel{Creator}
 and \xmlel{Contact}.
+\item Deprecated testQueryString in \xmlel{vr:Interface}.
 \end{itemize}
 
 


### PR DESCRIPTION
This is after this consideration:
http://mail.ivoa.net/pipermail/registry/2026-January/005642.html